### PR TITLE
Redirect Issues to "backintime" repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Issues
+    url: https://github.com/bit-team/backintime/issues/new
+    about: This redirects you to the Issue section of the main repository "backintime".

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 Introduction
 ============
-For further informations and see the `backintme <https://github.com/bit-team/backintime>`_ repository and it's `issue tracker <https://github.com/bit-team/backintime/issues>`_.
+For further information, see the `backintme <https://github.com/bit-team/backintime>`_ repository and its `issue tracker <https://github.com/bit-team/backintime/issues>`_.
 
 user-callback
 =============
 
-During backup process `Back In Time <https://github.com/bit-team/backintime>`_ can call a user-callback script at different steps.
+During the backup process, `Back In Time <https://github.com/bit-team/backintime>`_ can call a user-callback script at different steps.
 This callback is ``$XDG_CONFIG_HOME/backintime/user-callback`` 
 (by default ``$XDG_CONFIG_HOME`` is ``~/.config``).
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,11 @@
+Introduction
+============
+For further informations and see the `backintme <https://github.com/bit-team/backintime>`_ repository and it's `issue tracker <https://github.com/bit-team/backintime/issues>`_.
+
 user-callback
 =============
 
-During backup process Back In Time can call a user-callback script at different steps.
+During backup process `Back In Time <https://github.com/bit-team/backintime>`_ can call a user-callback script at different steps.
 This callback is ``$XDG_CONFIG_HOME/backintime/user-callback`` 
 (by default ``$XDG_CONFIG_HOME`` is ``~/.config``).
 


### PR DESCRIPTION
Dear @emtiu,.
as discussed on the bit-dev mailing list.

The intention is to redirect users to the "backintime" repo to centralize issue tracking there. The README now has  a link. And the "New Issue" button offers a redirect to the issue section in the "backintime" repo.

This need be merged into `master` to make the the issue template working.