### PR TITLE
Add user-callback with diagnostic info (eg. for examining problems)

### DIFF
--- a/user-callback.diagnostics
+++ b/user-callback.diagnostics
@@ -80,7 +80,7 @@ case $reason in
         # mountPoint="/media/<user>/<mount root folder>"   # insert your mount folder here
         # printLog "Mount point status: $(mount | grep '$mountPoint')"  # empty if not mounted!
         
-        # Check if a folder does exists and is readable (eg. the snapshot target folder)
+        # Check if a required path does exist and is readable (eg. the snapshot target folder)
         # testFolder="/path/to/snapshots"                  # insert your path to check here
         # if [[ -r $testFolder ]]; then
         #     printLog "Folder exists and can be read..."

--- a/user-callback.diagnostics
+++ b/user-callback.diagnostics
@@ -1,0 +1,99 @@
+#!/bin/bash
+#    Copyright (c) 2012-2015 Germar Reitze, modified 2022 by J. Altfeld
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with this program; if not, write to the Free Software Foundation, Inc.,
+#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+#Script should return 0 if everything is alright. Returncode !0 will cancle
+#the running snapshot (BIT version >1.1.0).
+
+# This script is meant for debugging purposes only (to check when
+# and how the backup process is started and snapshots are taken.
+# You can also add further checks (eg. check for existing mounts
+# or readable paths to diagnose problems with inaccessible mounts).
+
+profile_id="$1"
+profile_name="$2"
+reason="$3"
+
+
+printLog() {
+    # argument $1 contains the log message
+    echo "$(date +'%Y-%m-%d %H:%M:%S') ($(whoami)/$BASHPID) profile_id=$profile_id: $1" 2>&1 >> ~/backintime_usercallback_diagnostics.log
+}
+
+case $reason in
+    1) #Backup process begins
+        printLog "1 - backup process begins"
+        ;;
+    2) #Backup process ends
+        printLog "2 - backup process ends"
+        ;;
+    3) #A new snapshot was taken
+        snapshot_id="$4"
+        snapshot_name="$5"
+        printLog "3 - backup process begins (snapshot_id=$snapshot_id - snapshot_name=$snapshot_name)"
+        ;;
+    4) #There was an error
+        errorcode="$4"
+        case $errorcode in
+            1) # ERROR: The application is not configured
+               printLog "4 - ERROR $errorcode: The application is not configured"
+              ;;
+            2) # ERROR: A 'take snapshot' process is already running
+               printLog "4 - ERROR $errorcode: A 'take snapshot' process is already running"
+              ;;
+            3) # ERROR: Can't find snapshots folder (is it on a removable drive ?)
+               printLog "4 - ERROR $errorcode: Can't find snapshots folder (maybe it is on a removable drive)"
+              ;;
+            4) # ERROR: A snapshot for 'now' already exist
+               printLog "4 - ERROR $errorcode: A snapshot for 'now' already exist"
+               ;;
+            *) # Unknown error number
+               printLog "4 - ERROR $errorcode: Unknown error code!"
+               ;;
+        esac
+        ;;
+    5) #backintime-qt4 (GUI) started
+        printLog "5 - backintime-qt GUI started"
+        ;;
+    6) #backintime-qt4 (GUI) closed
+        printLog "6 - backintime-qt GUI closed"
+        ;;
+    7) #Mount drives
+        printLog "7 - mount drive requested"
+        # Further diagnostics examples (use "on demand"):
+        
+        # Check if a mount point is in the list of mounted devices
+        # mountPoint="/media/<user>/<mount root folder>"   # insert your mount folder here
+        # printLog "Mount point status: $(mount | grep '$mountPoint')"  # empty if not mounted!
+        
+        # Check if a folder does exists and is readable (eg. the snapshot target folder)
+        # testFolder="/path/to/snapshots"                  # insert your path to check here
+        # if [[ -r $testFolder ]]; then
+        #     printLog "Folder exists and can be read..."
+        # else
+        #     printLog "Folder does not exist or cannot be read (missing permissions?)"
+        # fi
+        
+        ;;
+    8) #Unmount the drives
+        printLog "8 - unmount drive requested"
+        ;;
+    *) ## Unknown reason
+        printLog "Called with invalid reason $reason"
+        ;;
+
+esac


### PR DESCRIPTION
Example user-callback script to log the calls only into a log file (eg. for debugging purposes).

This script shall eg. be used to diagnose bit-team/backintime#1308